### PR TITLE
Fix peerDependencies: include 5.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "git+https://github.com/hexojs/hexo-fontawesome.git"
   },
   "peerDependencies": {
-    "hexo": "3.x || 4.x"
+    "hexo": "3.x || 4.x || 5.x"
   },
   "optionalDependencies": {
     "@fortawesome/free-brands-svg-icons": "^5.9",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15902347/89768149-d0b8ba80-db2d-11ea-972d-7ed941038e7b.png)

I have use it in my theme, and also use hexo 5.x

It work fine