### PR TITLE
compatibility with hexo v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "git+https://github.com/hexojs/hexo-fontawesome.git"
   },
   "peerDependencies": {
-    "hexo": "3.x || 4.x || 5.x || 6.x"
+    "hexo": "3.x || 4.x || 5.x || 6.x || 7.x"
   },
   "optionalDependencies": {
     "@fortawesome/free-brands-svg-icons": "^5.15.4",


### PR DESCRIPTION
Just added hexo v7.x as a peerDependency, needed to install in hexo v7 projects.