### PR TITLE
chore: compatibility with hexo v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "git+https://github.com/hexojs/hexo-fontawesome.git"
   },
   "peerDependencies": {
-    "hexo": "3.x || 4.x || 5.x || 6.x || 7.x"
+    "hexo": "3.x || 4.x || 5.x || 6.x || 7.x || 8.x"
   },
   "optionalDependencies": {
     "@fortawesome/free-brands-svg-icons": "^5.15.4",


### PR DESCRIPTION
[Two years later](https://github.com/hexojs/hexo-fontawesome/pull/290)...

Just added hexo v8.x as a peerDependency, needed to install in hexo v8 projects.

@ertrzyiks 